### PR TITLE
chore: target .NET 10

### DIFF
--- a/RedBlack/RedBlack.csproj
+++ b/RedBlack/RedBlack.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/RedBlackBenchmark/RedBlackBenchmark.csproj
+++ b/RedBlackBenchmark/RedBlackBenchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Passe `<TargetFramework>` a `net10.0` sur 2 fichier(s).

**Verdict de l'oracle local avant PR** : `GREEN` -> `GREEN` (1/1 solutions vertes).

Fichiers :
- `RedBlack/RedBlack.csproj`
- `RedBlackBenchmark/RedBlackBenchmark.csproj`

Genere par `repo-audit/net10_sweep.py`. Merge uniquement si la CI est verte.