### PR TITLE
docs: add NuGetKeep backlink footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,10 @@ This project is available under a permissive license \(e.g. [MIT License](https:
 ---
 
 **Enjoy using the Red-Black Tree with order statistics and multiset support!** If you find any issues, please open an issue or create a pull request. Happy coding!
+
+<!-- portfolio-nugetkeep:start -->
+---
+Built by [Atypical Consulting](https://www.atypical.consulting). We also make
+[NuGetKeep](https://nugetkeep.com/?utm_source=github-readme&utm_medium=readme&utm_campaign=launch-2026-07),
+a self-hosted NuGet server with supply-chain quarantine.
+<!-- portfolio-nugetkeep:end -->


### PR DESCRIPTION
## Why

NuGetKeep (https://nugetkeep.com) is a self-hosted NuGet server this org also builds. It has zero customers and zero search-engine presence; this portfolio's own public .NET repos are read by exactly the audience it needs. This PR adds one footer line saying so.

## What

A single line in the README footer, wrapped in `<!-- portfolio-nugetkeep:start/end -->` so a re-run of the sweep replaces it in place instead of stacking copies. The UTM values (`utm_source=github-readme&utm_medium=readme&utm_campaign=launch-2026-07`) are fixed by `docs/ACQUISITION.md` §2 in the NuGetKeep repo and are the same on every repo this sweep touches — that consistency is what makes the traffic measurable at all.

No code, no CI-relevant file, and no other marker block in this README is touched.
